### PR TITLE
feat(polybar): use tray module instead of legacy tray implementation

### DIFF
--- a/polybar.ini
+++ b/polybar.ini
@@ -22,7 +22,7 @@ separator-foreground = ${colors.info-dark}
 
 modules-left = ewmh xwindow
 modules-center = date time
-modules-right = volume cpu wlan memory battery
+modules-right = volume cpu wlan memory battery tray
 padding-left = 1
 padding-right = 1
 radius = 10
@@ -31,7 +31,6 @@ border-color = #00000000
 
 cursor-click = pointer
 cursor-scroll = ns-resize
-tray-position = right
 
 module-margin = 1
 
@@ -138,3 +137,8 @@ format-discharging = <label-discharging>
 
 label-charging = " %{F#FEC601}C%{F#A0A0A0} %percentage%% "
 label-discharging = " %{F#FEC601}D%{F#A0A0A0} %percentage%% " 
+
+[module/tray]
+type = internal/tray
+tray-size = 100%
+tray-padding = 5px


### PR DESCRIPTION
> Polybar version 3.7 introduced the new tray module and deprecated the legacy tray implementation which uses `tray-position` to position the tray.

Reference: https://polybar.readthedocs.io/en/stable/migration/3.7/index.html#system-tray